### PR TITLE
feat: improve `MixModule` to handle default values

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -56,7 +56,6 @@ def test_arg_6():
 
 def test_arg_7():
     x = Dummy2(2, 3)
-    print(x.config.__dict__)
     assert x.config.__dict__["a"] == 2
     assert x.config.__dict__["b"] == 3
     assert x.config.__dict__["c"] == 3
@@ -125,7 +124,6 @@ class Dummy4(MixModule):
             nn.GELU(),
         ),
     ):
-        print(a)
         self.a = a
 
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,137 @@
+import pytest
+from hydra.utils import instantiate
+
+from torchmix import MixModule, nn
+
+
+class Dummy(MixModule):
+    def __init__(self, a, b=nn.Linear(1, 1)):
+        pass
+
+
+def test_arg_1():
+    x = Dummy(3)
+    assert x.config.__dict__["a"] == 3
+    assert x.config.__dict__["b"].__dict__["in_features"] == 1
+    assert x.config.__dict__["b"].__dict__["out_features"] == 1
+
+
+def test_arg_2():
+    x = Dummy(a=3)
+    assert x.config.__dict__["a"] == 3
+    assert x.config.__dict__["b"].__dict__["in_features"] == 1
+    assert x.config.__dict__["b"].__dict__["out_features"] == 1
+
+
+def test_arg_3():
+    x = Dummy(a=3, b=nn.Linear(2, 2))
+    assert x.config.__dict__["a"] == 3
+    assert x.config.__dict__["b"].__dict__["in_features"] == 2
+    assert x.config.__dict__["b"].__dict__["out_features"] == 2
+
+
+def test_arg_4():
+    x = Dummy(3, b=nn.Linear(2, 2))
+    assert x.config.__dict__["a"] == 3
+    assert x.config.__dict__["b"].__dict__["in_features"] == 2
+    assert x.config.__dict__["b"].__dict__["out_features"] == 2
+
+
+def test_arg_5():
+    with pytest.raises(TypeError):
+        Dummy(b=nn.Linear(2, 2))
+
+
+class Dummy2(MixModule):
+    def __init__(self, a=1, b=2, c=3):
+        pass
+
+
+def test_arg_6():
+    x = Dummy2(2)
+    assert x.config.__dict__["a"] == 2
+    assert x.config.__dict__["b"] == 2
+    assert x.config.__dict__["c"] == 3
+
+
+def test_arg_7():
+    x = Dummy2(2, 3)
+    print(x.config.__dict__)
+    assert x.config.__dict__["a"] == 2
+    assert x.config.__dict__["b"] == 3
+    assert x.config.__dict__["c"] == 3
+
+
+def test_arg_8():
+    x = Dummy2(2, 3, 4)
+    assert x.config.__dict__["a"] == 2
+    assert x.config.__dict__["b"] == 3
+    assert x.config.__dict__["c"] == 4
+
+
+def test_arg_9():
+    x = Dummy2(2, 3, c=4)
+    assert x.config.__dict__["a"] == 2
+    assert x.config.__dict__["b"] == 3
+    assert x.config.__dict__["c"] == 4
+
+
+class Dummy3(MixModule):
+    def __init__(self, a, b, c, d=4, e=5):
+        pass
+
+
+def test_arg_10():
+    x = Dummy3(a=1, b=2, c=3)
+    assert x.config.__dict__["a"] == 1
+    assert x.config.__dict__["b"] == 2
+    assert x.config.__dict__["c"] == 3
+    assert x.config.__dict__["d"] == 4
+    assert x.config.__dict__["e"] == 5
+
+
+def test_arg_11():
+    x = Dummy3(1, b=2, c=3)
+    assert x.config.__dict__["a"] == 1
+    assert x.config.__dict__["b"] == 2
+    assert x.config.__dict__["c"] == 3
+    assert x.config.__dict__["d"] == 4
+    assert x.config.__dict__["e"] == 5
+
+
+def test_arg_12():
+    x = Dummy3(1, 2, c=3)
+    assert x.config.__dict__["a"] == 1
+    assert x.config.__dict__["b"] == 2
+    assert x.config.__dict__["c"] == 3
+    assert x.config.__dict__["d"] == 4
+    assert x.config.__dict__["e"] == 5
+
+
+def test_arg_13():
+    x = Dummy3(1, 2, c=3, e=6)
+    assert x.config.__dict__["a"] == 1
+    assert x.config.__dict__["b"] == 2
+    assert x.config.__dict__["c"] == 3
+    assert x.config.__dict__["d"] == 4
+    assert x.config.__dict__["e"] == 6
+
+
+class Dummy4(MixModule):
+    def __init__(
+        self,
+        a=nn.Sequential(
+            nn.Linear(1, 2),
+            nn.GELU(),
+        ),
+    ):
+        print(a)
+        self.a = a
+
+
+def test_arg_14():
+    x = Dummy4()
+    assert type(x.a) == nn.Sequential
+    assert type(instantiate(x.config).a) == nn.Sequential
+    assert x.config.__dict__["a"].__dict__["_args_"][0].__dict__["in_features"] == 1
+    assert x.config.__dict__["a"].__dict__["_args_"][0].__dict__["out_features"] == 2

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -58,5 +58,4 @@ testdata = [
 
 @pytest.mark.parametrize("module,num_parameters", testdata)
 def test_export(module: MixModule, num_parameters: int):
-    print(module)
     assert sum(p.numel() for p in module.parameters()) == num_parameters

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -1,0 +1,51 @@
+from hydra_zen import to_yaml
+
+from torchmix.third_party.einops import EinMix
+
+
+def test_einmix1():
+    model = EinMix(
+        "b n d_in -> b n d_out",
+        weight_shape="d_in d_out",
+        bias_shape="d_out",
+        d_in=1,
+        d_out=2,
+    )
+    print(to_yaml(model.config))
+    assert model.config.__dict__["pattern"] == "b n d_in -> b n d_out"
+    assert model.config.__dict__["weight_shape"] == "d_in d_out"
+    assert model.config.__dict__["bias_shape"] == "d_out"
+    assert model.config.__dict__["d_in"] == 1
+    assert model.config.__dict__["d_out"] == 2
+
+
+def test_einmix2():
+    model = EinMix(
+        "b n d_in -> b n d_out",
+        "d_in d_out",
+        bias_shape="d_out",
+        d_in=1,
+        d_out=2,
+    )
+    print(to_yaml(model.config))
+    assert model.config.__dict__["pattern"] == "b n d_in -> b n d_out"
+    assert model.config.__dict__["weight_shape"] == "d_in d_out"
+    assert model.config.__dict__["bias_shape"] == "d_out"
+    assert model.config.__dict__["d_in"] == 1
+    assert model.config.__dict__["d_out"] == 2
+
+
+def test_einmix3():
+    model = EinMix(
+        "b n d_in -> b n d_out",
+        "d_in d_out",
+        "d_out",
+        d_in=1,
+        d_out=2,
+    )
+    print(to_yaml(model.config))
+    assert model.config.__dict__["pattern"] == "b n d_in -> b n d_out"
+    assert model.config.__dict__["weight_shape"] == "d_in d_out"
+    assert model.config.__dict__["bias_shape"] == "d_out"
+    assert model.config.__dict__["d_in"] == 1
+    assert model.config.__dict__["d_out"] == 2

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -1,5 +1,3 @@
-from hydra_zen import to_yaml
-
 from torchmix.third_party.einops import EinMix
 
 
@@ -11,7 +9,6 @@ def test_einmix1():
         d_in=1,
         d_out=2,
     )
-    print(to_yaml(model.config))
     assert model.config.__dict__["pattern"] == "b n d_in -> b n d_out"
     assert model.config.__dict__["weight_shape"] == "d_in d_out"
     assert model.config.__dict__["bias_shape"] == "d_out"
@@ -27,7 +24,6 @@ def test_einmix2():
         d_in=1,
         d_out=2,
     )
-    print(to_yaml(model.config))
     assert model.config.__dict__["pattern"] == "b n d_in -> b n d_out"
     assert model.config.__dict__["weight_shape"] == "d_in d_out"
     assert model.config.__dict__["bias_shape"] == "d_out"
@@ -43,7 +39,6 @@ def test_einmix3():
         d_in=1,
         d_out=2,
     )
-    print(to_yaml(model.config))
     assert model.config.__dict__["pattern"] == "b n d_in -> b n d_out"
     assert model.config.__dict__["weight_shape"] == "d_in d_out"
     assert model.config.__dict__["bias_shape"] == "d_out"


### PR DESCRIPTION
`MixModule` can now parse configurations from default values in the constructor.

```python
class CustomModule(MixModule):
    def __init__(
        self,
        a=nn.Sequential(
            nn.Linear(1, 2),
            nn.GELU(),
        ),
    ):
        pass
        
CustomModule().export()
```

before:
```
hydra_zen.errors.HydraZenUnsupportedPrimitiveError: Building: CustomModule ..
 The configured value Sequential(
  (0): Linear(in_features=1, out_features=2, bias=True)
  (1): GELU(approximate='none')
), for field `a`, is not supported by Hydra -- serializing or instantiating this config would ultimately result in an error.
```

now: 
```yaml
_target_: __main__.CustomModule
a:
  _target_: torchmix.nn.Sequential
  _args_:
  - _target_: torchmix.nn.Linear
    in_features: 1
    out_features: 2
    bias: true
    device: null
    dtype: null
  - _target_: torchmix.nn.GELU
    approximate: none
```